### PR TITLE
Fix [FTL] error in shuffledns command on  Recon-E-dns-Brute-heavy.sh

### DIFF
--- a/modules/External/Recon-E-dns-Brute-heavy.sh
+++ b/modules/External/Recon-E-dns-Brute-heavy.sh
@@ -22,7 +22,7 @@ cat << EOF
 EOF
 
 echo "Run shuffledns & Brute force on: $1"
-shuffledns -d $1 -r ./wordlist/dns-resolvers.txt -w ./wordlist/dns-wordlist-heavy.txt -silent -o $1.dnsBrute.txt
+shuffledns -d $1 -r ./wordlist/dns-resolvers.txt -w ./wordlist/dns-wordlist-heavy.txt -silent -o $1.dnsBrute.txt -mode bruteforce
 echo "shuffledns Done & result in $1.dnsBrute.txt ==> len: ` cat $1.dnsBrute.txt | wc -l `"
 
 echo "Run dnsgen on: $1"
@@ -30,7 +30,7 @@ cat $2 $1.dnsBrute.txt | sort -u | dnsgen -w ./wordlist/dns-dnsgen-wordlist-heav
 echo "dnsgen Done & result in $1.dnsgen.txt ==> len: ` cat $1.dnsgen.txt | wc -l `"
 
 echo "Run shuffledns & Resolving on: $1.dnsgen.txt"
-shuffledns -l $1.dnsgen.txt -r ./wordlist/dns-resolvers.txt -silent -o $1.dnsBrute-gen.txt
+shuffledns -l $1.dnsgen.txt -r ./wordlist/dns-resolvers.txt -silent -o $1.dnsBrute-gen.txt -mode bruteforce
 echo "shuffledns Done & result in $1.dnsBrute-gen.txt ==> len: ` cat $1.dnsBrute-gen.txt | wc -l `"
 
 echo


### PR DESCRIPTION
**when run this command :**
shuffledns -d $1 -r ../../wordlist/dns-resolvers.txt -w ../../wordlist/all-subdomain.txt -silent -o $1.dnsBrute.txt
shuufledns return error : "**[FTL] Program exiting: resolver file doesn't exists**" 
to resolve this issue just add this parameter end of command "-mode bruteforce"
enjoy of this tool and happy hunting.